### PR TITLE
Add data inflation feature using pako library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "chart.js": "^3.9.1",
                 "chartjs-plugin-zoom": "^1.2.1",
                 "hammerjs": "^2.0.8",
+                "pako": "^2.1.0",
                 "path": "^0.12.7",
                 "posthtml": "^0.16.6",
                 "posthtml-toc": "^1.0.3",
@@ -4532,6 +4533,11 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "node_modules/parse-json": {
             "version": "5.2.0",
@@ -9585,6 +9591,11 @@
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
+        },
+        "pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
         },
         "parse-json": {
             "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
         "chart.js": "^3.9.1",
         "chartjs-plugin-zoom": "^1.2.1",
         "hammerjs": "^2.0.8",
+        "pako": "^2.1.0",
         "path": "^0.12.7",
         "posthtml": "^0.16.6",
         "posthtml-toc": "^1.0.3",

--- a/src/html/dataread.ts
+++ b/src/html/dataread.ts
@@ -1,3 +1,4 @@
+import pako from "pako";
 /**
  * This js script file collects functions to read the data form the file.
  */
@@ -8,6 +9,13 @@ export let dataBuffer: Uint8Array;
 export function setDataBuffer(val: Uint8Array) {
 	dataBuffer = val;
 }
+let inflated = false;
+export function inflateData() {
+	if (!inflated) {
+		dataBuffer = pako.inflate(dataBuffer);
+		inflated = true;
+	}
+};
 
 // Index into dataBuffer.
 export let lastOffset: number;

--- a/src/html/parser.ts
+++ b/src/html/parser.ts
@@ -1,5 +1,5 @@
 import {vscode} from './vscode-import';
-import {dataBuffer, lastOffset, lastSize, lastBitOffset, lastBitSize, startOffset, getDataBufferSize, getRelOffset, convertToHexString, correctBitByteOffsets, setLastOffset, setLastSize, setLastBitOffset, setLastBitSize, setStartOffset, setLittleEndian, read, readUntil, setOffset, getOffset, readBits, setEndianness, getNumberValue, getSignedNumberValue, getBitsValue, getHexValue, getHex0xValue, getDecimalValue, getSignedDecimalValue, getStringValue, getData, endOfFile, setDataBuffer} from './dataread';
+import {dataBuffer, lastOffset, lastSize, lastBitOffset, lastBitSize, startOffset, getDataBufferSize, getRelOffset, convertToHexString, correctBitByteOffsets, setLastOffset, setLastSize, setLastBitOffset, setLastBitSize, setStartOffset, setLittleEndian, read, readUntil, setOffset, getOffset, readBits, setEndianness, getNumberValue, getSignedNumberValue, getBitsValue, getHexValue, getHex0xValue, getDecimalValue, getSignedDecimalValue, getStringValue, getData, endOfFile, setDataBuffer, inflateData} from './dataread';
 import {lastNode, setLastNode, addChart, createSeries} from './showcharts';
 import {addCanvas} from './canvas';
 
@@ -680,6 +680,7 @@ globalThis.parseStart = function () {
 			dbgLog,
 			dbgOverrideDetailsOpen,
 			endOfFile,
+			inflateData,
 
 			// Standard
 			Math,

--- a/tests/function.test.ts
+++ b/tests/function.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
-import {dataBuffer, convertToHexString, setLastOffset, setLastSize, setLastBitOffset, setLastBitSize, setLittleEndian, read, setOffset, getOffset, getNumberValue, getSignedNumberValue, getBitsValue, getHexValue, getHex0xValue, getDecimalValue, getSignedDecimalValue, getStringValue, setDataBuffer, _getDecimalValue, _getSignedDecimalValue, _getHexValue} from '../src/html/dataread';
+import pako from "pako";
+import {dataBuffer, convertToHexString, setLastOffset, setLastSize, setLastBitOffset, setLastBitSize, setLittleEndian, read, setOffset, getOffset, getNumberValue, getSignedNumberValue, getBitsValue, getHexValue, getHex0xValue, getDecimalValue, getSignedDecimalValue, getStringValue, setDataBuffer, _getDecimalValue, _getSignedDecimalValue, _getHexValue, inflateData} from '../src/html/dataread';
 
 
 /**
@@ -743,6 +744,16 @@ describe('Functions', () => {
 			});
 		});
 
+	});
+
+	describe('inflateData()', () => {
+		test('inflate', () => {
+			setDataBuffer(pako.deflate(new Uint8Array([0, 0x29, 0x2B, 0xDA, 0x78])));
+			inflateData();
+			setLastSize(dataBuffer.length - 1);
+			const s: String = getHexValue();
+			assert.equal(s.toString(), '78DA2B29');
+		});
 	});
 });
 


### PR DESCRIPTION
This pull request adds a new feature to the vscode plugin that allows the user to inflate compressed binary data using the [pako](https://github.com/nodeca/pako) library. The changes include importing the pako library in the dataread.ts file, adding a new function inflateData() to inflate the data buffer, and writing a test case for the new function. This feature enhances the plugin's functionality and provides a better user experience for viewing compressed binary files.